### PR TITLE
make anchor strategies for testnet

### DIFF
--- a/contracts/strategy/anchor/AnchorBaseStrategy.sol
+++ b/contracts/strategy/anchor/AnchorBaseStrategy.sol
@@ -51,19 +51,19 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
         0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08; // keccak256("MANAGER_ROLE");
 
     // Underlying token address
-    IERC20 public override(IStrategy) underlying;
+    IERC20 public immutable override(IStrategy) underlying;
 
     // Vault address
-    address public override(IStrategy) vault;
+    address public immutable override(IStrategy) vault;
 
     // Treasury address
     address public treasury;
 
     // UST token address
-    IERC20 public ustToken;
+    IERC20 public immutable ustToken;
 
     // aUST token address (wrapped Anchor UST, received to accrue interest for an Anchor deposit)
-    IERC20 public aUstToken;
+    IERC20 public immutable aUstToken;
 
     // performance fee taken by the treasury on profits
     uint16 public perfFeePct;
@@ -72,7 +72,7 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
     IEthAnchorRouter public ethAnchorRouter;
 
     // Chainlink aUST / UST price feed
-    AggregatorV3Interface public aUstToUstFeed;
+    AggregatorV3Interface public immutable aUstToUstFeed;
 
     // amount currently pending in deposits to EthAnchor
     uint256 public pendingDeposits;

--- a/contracts/strategy/anchor/AnchorNonUSTStrategy.sol
+++ b/contracts/strategy/anchor/AnchorNonUSTStrategy.sol
@@ -19,13 +19,13 @@ contract AnchorNonUSTStrategy is AnchorBaseStrategy {
     event Initialized();
 
     // UST / USDC / USDT / DAI curve pool address
-    ICurve public curvePool;
+    ICurve public immutable curvePool;
 
     // index of the underlying token in the curve pool
-    int128 public underlyingI;
+    int128 public immutable underlyingI;
 
     // index of the UST token in the curve pool
-    int128 public ustI;
+    int128 public immutable ustI;
 
     // flag to indicate initialization status
     bool public initialized;

--- a/contracts/test/strategy/IUniswapV2Router01.sol
+++ b/contracts/test/strategy/IUniswapV2Router01.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (
+            uint256 amountA,
+            uint256 amountB,
+            uint256 liquidity
+        );
+
+    function addLiquidityETH(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (
+            uint256 amountToken,
+            uint256 amountETH,
+            uint256 liquidity
+        );
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityETH(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function swapTokensForExactETH(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapETHForExactTokens(
+        uint256 amountOut,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) external pure returns (uint256 amountB);
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountOut);
+
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountIn);
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path)
+        external
+        view
+        returns (uint256[] memory amounts);
+
+    function getAmountsIn(uint256 amountOut, address[] calldata path)
+        external
+        view
+        returns (uint256[] memory amounts);
+}

--- a/contracts/test/strategy/TestAnchorNonUSTStrategy.sol
+++ b/contracts/test/strategy/TestAnchorNonUSTStrategy.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+import {AnchorNonUSTStrategy} from "../../strategy/anchor/AnchorNonUSTStrategy.sol";
+import {IExchangeRateFeeder} from "../../strategy/anchor/IExchangeRateFeeder.sol";
+import {IUniswapV2Router01} from "./IUniswapV2Router01.sol";
+
+/**
+ * AnchorNonUSTStrategy for testnet.
+ *
+ * Since aUST/UST chainlink does not exist on testnet, we use EthAnchorExchangeRateFeeder
+ * to get aUST/UST exchange rate.
+ * And we use uniswap V2 to swap underlying to UST and vice versa.
+ */
+contract TestAnchorNonUSTStrategy is AnchorNonUSTStrategy {
+    using SafeERC20 for IERC20;
+
+    IExchangeRateFeeder public exchangeRateFeeder;
+    IUniswapV2Router01 public uniV2Router;
+
+    /**
+     * @notice fake values are not being used.
+     */
+    constructor(
+        address _vault,
+        address _treasury,
+        address _ethAnchorRouter,
+        AggregatorV3Interface _aUstToUstFeed,
+        IExchangeRateFeeder _exchangeRateFeeder,
+        IERC20 _ustToken,
+        IERC20 _aUstToken,
+        uint16 _perfFeePct,
+        address _owner,
+        address _uniV2Router
+    )
+        AnchorNonUSTStrategy(
+            _vault,
+            _treasury,
+            _ethAnchorRouter,
+            _aUstToUstFeed,
+            _ustToken,
+            _aUstToken,
+            _perfFeePct,
+            _owner,
+            address(0x1), // fake curve address
+            0, // fake index
+            1 // fake index
+        )
+    {
+        exchangeRateFeeder = _exchangeRateFeeder;
+
+        _aUstToUstFeedMultiplier = 1e18;
+
+        uniV2Router = IUniswapV2Router01(_uniV2Router);
+
+        // No need to initialize chainlink feed, because they don't exist on testnet
+        initialized = true;
+    }
+
+    /**
+     * Swap Underlying to UST through uniswap V2
+     *
+     * @param minExchangeRate minimum exchange rate of Underlying/UST.
+     * @return swapped underlying amount
+     */
+    function _swapUnderlyingToUst(uint256 minExchangeRate)
+        internal
+        override
+        returns (uint256)
+    {
+        require(
+            minExchangeRate != 0,
+            "AnchorNonUSTStrategy: minExchangeRate is zero"
+        );
+        uint256 underlyingBalance = _getUnderlyingBalance();
+        require(
+            underlyingBalance > 0,
+            "AnchorNonUSTStrategy: no underlying exist"
+        );
+
+        address[] memory path = new address[](2);
+        path[0] = address(underlying);
+        path[1] = address(ustToken);
+        underlying.safeIncreaseAllowance(
+            address(uniV2Router),
+            underlyingBalance
+        );
+        uniV2Router.swapExactTokensForTokens(
+            underlyingBalance,
+            (underlyingBalance * minExchangeRate) / 1e18,
+            path,
+            address(this),
+            block.timestamp
+        );
+
+        return underlyingBalance;
+    }
+
+    /**
+     * Swap UST to Underlying through uniswap V2
+     *
+     * @param minAmount minimum underlying amount to receive.
+     */
+    function _swapUstToUnderlying(uint256 minAmount) internal override {
+        uint256 ustBalance = _getUstBalance();
+        require(ustBalance != 0, "AnchorNonUSTStrategy: no UST exist");
+
+        address[] memory path = new address[](2);
+        path[0] = address(ustToken);
+        path[1] = address(underlying);
+        ustToken.safeIncreaseAllowance(address(uniV2Router), ustBalance);
+        uniV2Router.swapExactTokensForTokens(
+            ustBalance,
+            minAmount,
+            path,
+            address(this),
+            block.timestamp
+        );
+    }
+
+    // get aUST/UST exchange rate from eth anchor ExchangeRateFeeder contract
+    function _aUstToUstExchangeRate() internal view override returns (uint256) {
+        return exchangeRateFeeder.exchangeRateOf(address(ustToken), true);
+    }
+
+    /**
+     * @return Underlying value of UST amount
+     *
+     * @notice This uses spot price on Uniswap V2, and this could lead an attack,
+     * however, since this is for testnet version, it is fine.
+     */
+    function _estimateUstAmountInUnderlying(uint256 ustAmount)
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        address[] memory path = new address[](2);
+        path[0] = address(ustToken);
+        path[1] = address(underlying);
+
+        uint256[] memory amountsOut = uniV2Router.getAmountsOut(
+            ustAmount,
+            path
+        );
+        return amountsOut[1];
+    }
+}

--- a/contracts/test/strategy/TestAnchorUSTStrategy.sol
+++ b/contracts/test/strategy/TestAnchorUSTStrategy.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+import {AnchorUSTStrategy} from "../../strategy/anchor/AnchorUSTStrategy.sol";
+import {IExchangeRateFeeder} from "../../strategy/anchor/IExchangeRateFeeder.sol";
+
+/**
+ * AnchorUSTStrategy for testnet.
+ * Since aUST/UST chainlink does not exist on testnet, we use EthAnchorExchangeRateFeeder
+ * to get aUST/UST exchange rate.
+ */
+contract TestAnchorUSTStrategy is AnchorUSTStrategy {
+    IExchangeRateFeeder public exchangeRateFeeder;
+
+    /**
+     * @notice _aUstToUstFeed is a fake chainlink feed, it is used to just
+     * inhert constructor of USTStrategy
+     */
+    constructor(
+        address _vault,
+        address _treasury,
+        address _ethAnchorRouter,
+        AggregatorV3Interface _aUstToUstFeed,
+        IExchangeRateFeeder _exchangeRateFeeder,
+        IERC20 _ustToken,
+        IERC20 _aUstToken,
+        uint16 _perfFeePct,
+        address _owner
+    )
+        AnchorUSTStrategy(
+            _vault,
+            _treasury,
+            _ethAnchorRouter,
+            _aUstToUstFeed,
+            _ustToken,
+            _aUstToken,
+            _perfFeePct,
+            _owner
+        )
+    {
+        exchangeRateFeeder = _exchangeRateFeeder;
+        _aUstToUstFeedMultiplier = 1e18;
+    }
+
+    // get aUST/UST exchange rate from eth anchor ExchangeRateFeeder contract
+    function _aUstToUstExchangeRate() internal view override returns (uint256) {
+        return exchangeRateFeeder.exchangeRateOf(address(ustToken), true);
+    }
+}


### PR DESCRIPTION
Testnet does not have aUST/UST chainlink feed, and unable to swap tokens via curve.
So we make testnet strategies which inherits production strategies and override required functions. 