### PR TITLE
[WP-H2] complete pending withdrawal before initiating another one (RyskStrategy#withdrawToVault)

### DIFF
--- a/test/strategy/rysk/RyskStrategy.fork.spec.ts
+++ b/test/strategy/rysk/RyskStrategy.fork.spec.ts
@@ -210,7 +210,7 @@ describe('Rysk Strategy (mainnet fork tests)', () => {
       expect(await strategy.investedAssets()).to.gte('999999995');
     });
 
-    it('fails if called without completing withdrawal from previous epoch', async () => {
+    it('completes the pending withdrawal from previous epoch', async () => {
       const amount = parseUSDC('1000');
       await ForkHelpers.mintToken(usdc, strategy.address, amount);
 
@@ -218,12 +218,15 @@ describe('Rysk Strategy (mainnet fork tests)', () => {
 
       await executeEpochCalculation();
 
-      await strategy.connect(admin).withdrawToVault(amount.div(2));
+      const halfAmount = amount.div(2);
+      await strategy.connect(admin).withdrawToVault(halfAmount);
 
       await executeEpochCalculation();
 
-      await expect(strategy.connect(admin).withdrawToVault(amount.div(2))).to.be
-        .reverted;
+      await expect(strategy.connect(admin).withdrawToVault(halfAmount)).to.not
+        .be.reverted;
+
+      expect(await usdc.balanceOf(vault.address)).to.eq('499999998'); // rounding error
     });
   });
 


### PR DESCRIPTION
Addressing issue WP-H2 from the audit report - _checkPendingWithdrawal() should trigger completeWithdrawal()