### PR TITLE
Fix Claimer Principal Calculation Bug

### DIFF
--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -191,7 +191,7 @@ export function handleDepositWithdrawn(event: DepositWithdrawn): void {
 
   const vault = createVault();
 
-  claimer.principal = claimer.principal.minus(deposit.amount);
+  claimer.principal = claimer.principal.minus(event.params.amount);
   claimer.shares = claimer.shares.minus(event.params.shares);
 
   if (event.params.burned) {

--- a/subgraph/tests/unit.test.ts
+++ b/subgraph/tests/unit.test.ts
@@ -324,6 +324,7 @@ test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", ()
   let mockEvent = newMockEvent();
 
   const claimer = new Claimer('1');
+  claimer.principal = BigInt.fromI32(10);
   claimer.save();
 
   const deposit = new Deposit('1');
@@ -373,6 +374,7 @@ test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", ()
   assert.fieldEquals('Foundation', '1', 'amountDeposited', '5');
   assert.fieldEquals('Foundation', '1', 'initialAmountDeposited', '10');
   assert.fieldEquals('Foundation', '1', 'shares', '5');
+  assert.fieldEquals('Claimer', '1', 'principal', '5');
 });
 
 test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {


### PR DESCRIPTION
The subgraph was badly calculating the claimer's principal when a partial withdrawal happened. Every time a `DepositWithdrawn` event happened, the handler was subtracting the whole deposit amount from the claimer's principal instead of just the amount on the event.

A simple example.
- There is a 100 unit deposit, and there is a claimer with 100 principal;
- The claimer withdraws 20 units, 2 times.
- The claimer principal should then be 60, but it is -100 (100 - 100 - 100, instead of 100 - 20 - 20)